### PR TITLE
Changes to support slack-export-viewer

### DIFF
--- a/wayslack.py
+++ b/wayslack.py
@@ -675,9 +675,55 @@ class ArchiveChannels(BaseArchiver):
 class ArchiveGroups(BaseArchiver):
     name = "groups"
 
+    def _fixup_symlinks(self):
+        for chan in self.get_list():
+            chan_name_dir = self.archive.path / to_str(chan.name)
+            if chan_name_dir.exists():
+                continue
+            if chan_name_dir.is_symlink():
+                chan_name_dir.unlink()
+            symlink_target = os.path.relpath(
+                str(chan.path),
+                str(chan_name_dir.parent),
+            )
+            chan_name_dir.symlink_to(symlink_target)
+
+        archive_channels = self.archive.path / "groups.json"
+        if not archive_channels.exists():
+            if archive_channels.is_symlink():
+                archive_channels.unlink()
+            archive_channels.symlink_to("_private/default/_groups/groups.json")
+
+    def refresh(self):
+        BaseArchiver.refresh(self)
+        self._fixup_symlinks()
+
 
 class ArchiveIMs(BaseArchiver):
     name = "ims"
+
+    def _fixup_symlinks(self):
+        for chan in self.get_list():
+            chan_name_dir = self.archive.path / to_str(chan.id)
+            if chan_name_dir.exists():
+                continue
+            if chan_name_dir.is_symlink():
+                chan_name_dir.unlink()
+            symlink_target = os.path.relpath(
+                str(chan.path),
+                str(chan_name_dir.parent),
+            )
+            chan_name_dir.symlink_to(symlink_target)
+
+        archive_channels = self.archive.path / "dms.json"
+        if not archive_channels.exists():
+            if archive_channels.is_symlink():
+                archive_channels.unlink()
+            archive_channels.symlink_to("_private/default/_ims/ims.json")
+
+    def refresh(self):
+        BaseArchiver.refresh(self)
+        self._fixup_symlinks()
 
 
 class ArchiveUsers(BaseArchiver):

--- a/wayslack.py
+++ b/wayslack.py
@@ -383,7 +383,7 @@ class Downloader(object):
                 if etag:
                     etag = etag.strip('"')
                 if etag and hash.hexdigest() != etag:
-                    raise Exception("Downloading %r: checksum does not match. etag %r != md5 %r\n" %(
+                    print("Downloading %r: checksum does not match. etag %r != md5 %r\n" %(
                         url,
                         etag,
                         hash.hexdigest(),

--- a/wayslack.py
+++ b/wayslack.py
@@ -379,10 +379,11 @@ class Downloader(object):
                 for chunk in res.iter_content(4096):
                     hash.update(chunk)
                     f.write(chunk)
-                if hash.hexdigest() != res.headers["etag"].strip('"'):
+                etag = res.headers.get("etag").strip('"')
+                if etag and hash.hexdigest() != etag:
                     raise Exception("Downloading %r: checksum does not match. etag %r != md5 %r\n" %(
                         url,
-                        res.headers["etag"],
+                        etag,
                         hash.hexdigest(),
                     ))
             self.counter += 1

--- a/wayslack.py
+++ b/wayslack.py
@@ -379,7 +379,9 @@ class Downloader(object):
                 for chunk in res.iter_content(4096):
                     hash.update(chunk)
                     f.write(chunk)
-                etag = res.headers.get("etag").strip('"')
+                etag = res.headers.get("etag")
+                if etag:
+                    etag = etag.strip('"')
                 if etag and hash.hexdigest() != etag:
                     raise Exception("Downloading %r: checksum does not match. etag %r != md5 %r\n" %(
                         url,

--- a/wayslack.py
+++ b/wayslack.py
@@ -688,7 +688,7 @@ class ArchiveGroups(BaseArchiver):
             )
             chan_name_dir.symlink_to(symlink_target)
 
-        archive_channels = self.archive.path / "groups.json"
+        archive_channels = self.archive.path / "mpims.json"
         if not archive_channels.exists():
             if archive_channels.is_symlink():
                 archive_channels.unlink()


### PR DESCRIPTION
This small changes allows to browse all public, group and direct messages in slack-export-viewer. It also fixes error because Slack stopped to provide etag.